### PR TITLE
Initialise bioc vignettes and fix metadata bug

### DIFF
--- a/R/AnansiWeb-constructors.R
+++ b/R/AnansiWeb-constructors.R
@@ -82,7 +82,8 @@ weaveWeb <- function(x, ...) UseMethod("weaveWeb")
 #' @order 2
 #' @export
 #'
-weaveWeb.default <- function(x, y, link = NULL, tableX = NULL, tableY = NULL, ...){
+weaveWeb.default <- function(x, y, link = NULL, tableX = NULL, tableY = NULL,
+                             metadata = NULL, ...){
   terms <- c(x, y)
   stopifnot("both 'x' and 'y' terms must be provided as character" =
               is(terms, "character") && length(terms) == 2L)

--- a/vignettes/anansi.Rmd
+++ b/vignettes/anansi.Rmd
@@ -216,6 +216,55 @@ ggplot(anansiLong) +
   xlab("Pearson's \u03c1")
 ```
 
+# Bioconductor pipeline
+
+anansi also supports the Bioconductor class MultiAssayExperiment (MAE) as an
+alternative to AnansiWeb. The latter can be converted to a MAE with the
+function `asMAE`.
+
+```{r}
+#| bioc1, eval=TRUE
+
+# Store sample metadata into metadata slot of web object
+web@metadata <- DataFrame(FMT_metadata, row.names = FMT_metadata$Sample_ID)
+# Ensure that metadata rows match tableX rows
+web@metadata <- web@metadata[match(rownames(web@tableX), rownames(web@metadata)), ]
+
+# Convert web to mae
+mae <- asMAE(web)
+```
+
+The MAE object can be passed to the `getAnansi` function, which returns the same
+output as `anansi`.
+
+```{r}
+#| bioc2, eval=TRUE
+
+# 
+out <- getAnansi(mae,
+    tableY = "cpd", tableX = "ko",
+    formula = ~ Legend,
+    adjust.method = "BH",
+    verbose = TRUE
+)
+```
+
+Finally, the output of anansi can be visualised with `plotAnansi` by specifying
+the type of association to use.
+
+```{r}
+#| bioc2, eval=TRUE, fig.width = 10, fig.height = 8
+
+# Filter associations by q value
+out <- out[out$full_q.values < 0.2, ]
+
+# Visualise disjointed associations
+plotAnansi(out,
+           association.type = "disjointed",
+           model.var = "Legend",
+           signif.threshold = 0.05,
+           fill_by = "Legend")
+```
 
 # Session info
 


### PR DESCRIPTION
Hi! I added a short Bioconductor pipeline to the anansi vignettes. It covers usage of `asMAE`, getAnansi` and `plotAnansi`.

There was a bug in the AnansiWeb constructor where the metadata was missing from the function arguments.

Looking forward to your feedback!

P.S.: Right now getAnansi looks a bit redundant with plain anansi function when using as input a MAE converted from an AnansiWeb. I think its original purpose was to easily create web and run anansi from MAE, but now that we have a web2mae converter I'm not sure if we should drop it in favour of just having an anansi method for MAE class.

Cheers,
Giulio